### PR TITLE
ci: add cargo audit autofix workflow

### DIFF
--- a/.codex/skills/inspequte-cargo-audit-fix/SKILL.md
+++ b/.codex/skills/inspequte-cargo-audit-fix/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: inspequte-cargo-audit-fix
+description: Fix Rust dependency audit failures in inspequte by reading cargo audit SARIF output, updating Cargo.toml or Cargo.lock with minimal dependency changes, and verifying with cargo build, cargo test, and cargo audit.
+---
+
+# inspequte cargo audit fix
+
+## Inputs
+- `cargo audit --format sarif` output, usually `target/audit-input/audit.sarif` or `target/audit.sarif`.
+- `Cargo.toml` and `Cargo.lock`.
+- The minimum surrounding files needed to understand dependency use.
+
+## Outputs
+- Minimal dependency updates in `Cargo.lock`.
+- `Cargo.toml` updates only when a direct dependency constraint prevents resolving a fixed version.
+- A clear final report listing fixed advisories and any unresolved manual follow-ups.
+
+## Workflow
+1. Read the SARIF report and identify each affected crate, current version, advisory ID, severity, and fixed version or patched range.
+2. Prefer lockfile-only updates:
+   - Run `cargo update -p <crate> --precise <fixed_version>` when SARIF or RustSec data gives one concrete fixed version.
+   - If only a version range is available, choose the lowest compatible patched version.
+3. Edit `Cargo.toml` only when the fixed version cannot be selected under the existing direct dependency requirement.
+4. Keep changes narrowly scoped to the vulnerable dependency and resolver-required transitive updates.
+5. Do not add compatibility shims, alternate dependency paths, or unrelated crate upgrades.
+6. Run `cargo fmt` after code or manifest changes.
+7. Verify with:
+   - `cargo build`
+   - `cargo test`
+   - `cargo audit --format sarif`
+8. If verification fails, continue only when the next step is clear from the error. Otherwise stop and report:
+   - unresolved crate or advisory
+   - attempted update
+   - blocking error
+   - required human decision
+
+## Guardrails
+- Treat the SARIF report as the source of truth for the audit failure being fixed.
+- Prefer simplicity over backward compatibility.
+- Do not update unrelated dependencies for freshness.
+- Do not ignore advisories or add audit suppressions.
+- Preserve Conventional Commit style when committing: `fix(deps): resolve cargo audit findings`.
+- Use ASCII-only edits unless a touched file already requires Unicode.
+
+## Definition of Done
+- `cargo audit --format sarif` exits successfully.
+- `cargo build` and `cargo test` pass.
+- The diff is limited to dependency files unless source changes are necessary for the dependency update.
+- Any unresolved advisory is documented with concrete evidence.

--- a/.codex/skills/inspequte-cargo-audit-fix/agents/openai.yaml
+++ b/.codex/skills/inspequte-cargo-audit-fix/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Cargo Audit Fix"
+  short_description: "Fix Rust dependency audit failures"
+  default_prompt: "Use $inspequte-cargo-audit-fix to update dependencies from a cargo audit SARIF report."
+policy:
+  allow_implicit_invocation: true

--- a/.github/workflows/cargo-audit-autofix.yml
+++ b/.github/workflows/cargo-audit-autofix.yml
@@ -38,7 +38,9 @@ jobs:
           EVENT_NAME: ${{ github.event.workflow_run.event }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          PR_HEAD_REF: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
+          PR_HEAD_REPOSITORY: ${{ github.event.workflow_run.pull_requests[0].head.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
           REPOSITORY: ${{ github.repository }}
           TRIGGER_RUN_URL: ${{ github.event.workflow_run.html_url }}
         shell: bash
@@ -57,11 +59,11 @@ jobs:
             checkout_ref="${HEAD_SHA}"
             source_ref="${DEFAULT_BRANCH}"
             source_kind="main"
-          elif [[ "${EVENT_NAME}" == "pull_request" && "${HEAD_REPOSITORY}" == "${REPOSITORY}" && -n "${HEAD_BRANCH}" ]]; then
+          elif [[ "${EVENT_NAME}" == "pull_request" && "${PR_HEAD_REPOSITORY}" == "${REPOSITORY}" && -n "${PR_HEAD_REF}" && -n "${PR_HEAD_SHA}" ]]; then
             eligible="true"
-            base_ref="${HEAD_BRANCH}"
-            checkout_ref="${HEAD_SHA}"
-            source_ref="${HEAD_BRANCH}"
+            base_ref="${PR_HEAD_REF}"
+            checkout_ref="${PR_HEAD_SHA}"
+            source_ref="${PR_HEAD_REF}"
             source_kind="internal-pr"
           fi
 

--- a/.github/workflows/cargo-audit-autofix.yml
+++ b/.github/workflows/cargo-audit-autofix.yml
@@ -1,0 +1,348 @@
+name: Cargo Audit Autofix
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+concurrency:
+  group: cargo-audit-autofix
+  cancel-in-progress: false
+
+env:
+  AUTOFIX_LABEL: cargo-audit-autofix
+  REVIEWER: KengoTODA
+
+jobs:
+  triage:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      eligible: ${{ steps.scope.outputs.eligible }}
+      has_audit_sarif: ${{ steps.artifact.outputs.has_audit_sarif }}
+      base_ref: ${{ steps.scope.outputs.base_ref }}
+      checkout_ref: ${{ steps.scope.outputs.checkout_ref }}
+      source_ref: ${{ steps.scope.outputs.source_ref }}
+      source_kind: ${{ steps.scope.outputs.source_kind }}
+      trigger_run_url: ${{ steps.scope.outputs.trigger_run_url }}
+    steps:
+      - name: Determine eligible source
+        id: scope
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event.workflow_run.event }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          REPOSITORY: ${{ github.repository }}
+          TRIGGER_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          eligible="false"
+          base_ref=""
+          checkout_ref=""
+          source_ref=""
+          source_kind=""
+
+          if [[ "${EVENT_NAME}" == "push" && "${HEAD_BRANCH}" == "${DEFAULT_BRANCH}" ]]; then
+            eligible="true"
+            base_ref="${DEFAULT_BRANCH}"
+            checkout_ref="${HEAD_SHA}"
+            source_ref="${DEFAULT_BRANCH}"
+            source_kind="main"
+          elif [[ "${EVENT_NAME}" == "pull_request" && "${HEAD_REPOSITORY}" == "${REPOSITORY}" && -n "${HEAD_BRANCH}" ]]; then
+            eligible="true"
+            base_ref="${HEAD_BRANCH}"
+            checkout_ref="${HEAD_SHA}"
+            source_ref="${HEAD_BRANCH}"
+            source_kind="internal-pr"
+          fi
+
+          {
+            echo "eligible=${eligible}"
+            echo "base_ref=${base_ref}"
+            echo "checkout_ref=${checkout_ref}"
+            echo "source_ref=${source_ref}"
+            echo "source_kind=${source_kind}"
+            echo "trigger_run_url=${TRIGGER_RUN_URL}"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "## Cargo audit autofix triage"
+            echo ""
+            echo "- eligible: \`${eligible}\`"
+            echo "- source-kind: \`${source_kind:-skipped}\`"
+            echo "- source-ref: \`${source_ref:-n/a}\`"
+            echo "- triggering run: ${TRIGGER_RUN_URL}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Check for cargo audit SARIF artifact
+        id: artifact
+        if: steps.scope.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifact_id="$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${TRIGGER_RUN_ID}/artifacts" \
+            --jq '.artifacts[] | select(.name == "cargo-audit-sarif" and .expired == false) | .id' \
+            | head -n1)"
+
+          if [[ -n "${artifact_id}" ]]; then
+            echo "has_audit_sarif=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_audit_sarif=false" >> "${GITHUB_OUTPUT}"
+            echo "- cargo-audit-sarif artifact: \`missing\`" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+  autofix:
+    needs: triage
+    if: needs.triage.outputs.eligible == 'true' && needs.triage.outputs.has_audit_sarif == 'true'
+    runs-on: ubuntu-latest
+    environment: codex
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Create app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.APP_ID_CODEX }}
+          private-key: ${{ secrets.PRIVATE_KEY_CODEX }}
+
+      - name: Check for existing autofix PR
+        id: existing_pr
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          AUTOFIX_LABEL: ${{ env.AUTOFIX_LABEL }}
+          SOURCE_REF: ${{ needs.triage.outputs.source_ref }}
+          TRIGGER_RUN_URL: ${{ needs.triage.outputs.trigger_run_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          existing_number="$(gh pr list \
+            --state open \
+            --json number,labels \
+            --jq ".[] | select(any(.labels[].name; . == \"${AUTOFIX_LABEL}\")) | .number" \
+            | head -n1)"
+
+          if [[ -n "${existing_number}" ]]; then
+            comment_body="${RUNNER_TEMP}/cargo-audit-existing-pr.md"
+            cat > "${comment_body}" <<EOF
+          Another cargo audit failure was detected while this autofix PR is open.
+
+          - source ref: \`${SOURCE_REF}\`
+          - triggering run: ${TRIGGER_RUN_URL}
+
+          This workflow keeps only one \`${AUTOFIX_LABEL}\` PR open at a time.
+          EOF
+            gh pr comment "${existing_number}" --body-file "${comment_body}"
+            echo "found=true" >> "${GITHUB_OUTPUT}"
+            echo "number=${existing_number}" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## Cargo audit autofix"
+              echo ""
+              echo "- action: \`reused-existing-pr\`"
+              echo "- pr: #${existing_number}"
+            } >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "found=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Checkout source ref
+        if: steps.existing_pr.outputs.found != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.triage.outputs.checkout_ref }}
+
+      - name: Download cargo audit SARIF
+        if: steps.existing_pr.outputs.found != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/audit-input
+          gh run download "${TRIGGER_RUN_ID}" \
+            --name cargo-audit-sarif \
+            --dir target/audit-input
+          audit_file="$(find target/audit-input -type f -name 'audit.sarif' | head -n1)"
+          if [[ -z "${audit_file}" ]]; then
+            echo "Downloaded cargo-audit-sarif artifact does not contain audit.sarif." >&2
+            exit 1
+          fi
+          if [[ "${audit_file}" != "target/audit-input/audit.sarif" ]]; then
+            cp "${audit_file}" target/audit-input/audit.sarif
+          fi
+          test -s target/audit-input/audit.sarif
+
+      - name: Write Codex prompt
+        if: steps.existing_pr.outputs.found != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/codex-workflow/prompts target/codex-workflow/output
+          cat > target/codex-workflow/prompts/cargo-audit-autofix.md <<'PROMPT'
+          You are Codex in this repository.
+
+          Use `.codex/skills/inspequte-cargo-audit-fix/SKILL.md`.
+
+          Inputs:
+          - cargo audit SARIF: `target/audit-input/audit.sarif`
+          - dependency manifests: `Cargo.toml`, `Cargo.lock`
+
+          Task:
+          1. Read the cargo audit SARIF and identify the vulnerable dependency updates needed.
+          2. Update dependencies with the smallest dependency change that resolves the advisories.
+          3. Prefer lockfile-only `cargo update -p <crate> --precise <fixed_version>` changes.
+          4. Edit `Cargo.toml` only if the direct dependency requirement blocks the fixed version.
+          5. Run `cargo fmt`, `cargo build`, `cargo test`, and `cargo audit --format sarif`.
+
+          Final response format:
+          - Summarize advisories fixed.
+          - Summarize files changed.
+          - Report verification commands and outcomes.
+          - If unresolved, state the crate, advisory, attempted update, and blocker.
+          PROMPT
+
+      - name: Codex cargo audit autofix
+        if: steps.existing_pr.outputs.found != 'true'
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          safety-strategy: drop-sudo
+          prompt-file: target/codex-workflow/prompts/cargo-audit-autofix.md
+          output-file: target/codex-workflow/output/cargo-audit-autofix-final-message.txt
+          sandbox: workspace-write
+          codex-args: --full-auto
+
+      - name: Check for dependency changes
+        if: steps.existing_pr.outputs.found != 'true'
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## Cargo audit autofix"
+              echo ""
+              echo "- action: \`no-changes\`"
+              echo "- reason: Codex did not produce dependency updates."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Verify dependency update
+        if: steps.existing_pr.outputs.found != 'true' && steps.diff.outputs.has_changes == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! command -v cargo-audit >/dev/null 2>&1; then
+            cargo install cargo-audit --locked
+          fi
+
+          cargo fmt > target/codex-workflow/output/cargo-fmt.txt 2>&1
+          cargo build > target/codex-workflow/output/cargo-build.txt 2>&1
+          cargo test > target/codex-workflow/output/cargo-test.txt 2>&1
+          cargo audit --format sarif > target/codex-workflow/output/cargo-audit.sarif 2> target/codex-workflow/output/cargo-audit.stderr
+
+          {
+            echo "## Cargo audit autofix verification"
+            echo ""
+            echo "- cargo fmt: \`pass\`"
+            echo "- cargo build: \`pass\`"
+            echo "- cargo test: \`pass\`"
+            echo "- cargo audit: \`pass\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Commit, push, and create PR
+        if: steps.existing_pr.outputs.found != 'true' && steps.diff.outputs.has_changes == 'true'
+        id: create_pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          AUTOFIX_LABEL: ${{ env.AUTOFIX_LABEL }}
+          REVIEWER: ${{ env.REVIEWER }}
+          BASE_REF: ${{ needs.triage.outputs.base_ref }}
+          SOURCE_REF: ${{ needs.triage.outputs.source_ref }}
+          SOURCE_KIND: ${{ needs.triage.outputs.source_kind }}
+          TRIGGER_RUN_URL: ${{ needs.triage.outputs.trigger_run_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          branch_name="codex/cargo-audit-autofix-${GITHUB_RUN_ID}"
+          git switch -c "${branch_name}"
+          git add -A
+          git commit -m "fix(deps): resolve cargo audit findings"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --set-upstream origin "${branch_name}"
+
+          body_file="target/codex-workflow/output/pr-body.md"
+          cat > "${body_file}" <<EOF
+          Generated by cargo-audit-autofix workflow.
+
+          - source kind: \`${SOURCE_KIND}\`
+          - source ref: \`${SOURCE_REF}\`
+          - triggering CI run: ${TRIGGER_RUN_URL}
+          EOF
+
+          pr_url="$(gh pr create \
+            --base "${BASE_REF}" \
+            --head "${branch_name}" \
+            --title "fix(deps): resolve cargo audit findings" \
+            --body-file "${body_file}")"
+          pr_number="$(gh pr view "${pr_url}" --json number --jq '.number')"
+
+          gh label create "${AUTOFIX_LABEL}" \
+            --description "Automated cargo audit dependency fix" \
+            --color "B60205" || true
+          gh pr edit "${pr_number}" --add-label "${AUTOFIX_LABEL}" --add-reviewer "${REVIEWER}"
+
+          {
+            echo "pr_number=${pr_number}"
+            echo "pr_url=${pr_url}"
+            echo "branch_name=${branch_name}"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "## Cargo audit autofix PR"
+            echo ""
+            echo "- pr: ${pr_url}"
+            echo "- reviewer: \`${REVIEWER}\`"
+            echo "- label: \`${AUTOFIX_LABEL}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload autofix artifacts
+        if: always() && steps.existing_pr.outputs.found != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cargo-audit-autofix
+          path: |
+            target/audit-input/audit.sarif
+            target/codex-workflow/prompts/cargo-audit-autofix.md
+            target/codex-workflow/output/**
+          if-no-files-found: warn

--- a/.github/workflows/cargo-audit-autofix.yml
+++ b/.github/workflows/cargo-audit-autofix.yml
@@ -112,7 +112,7 @@ jobs:
     environment: codex
     permissions:
       actions: read
-      contents: write
+      contents: read
       issues: write
       pull-requests: write
     steps:
@@ -303,6 +303,13 @@ jobs:
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 1
           fi
+
+      - name: Install Rust
+        if: steps.existing_pr.outputs.found != 'true' && steps.diff.outputs.has_changes == 'true'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: steps.existing_pr.outputs.found != 'true' && steps.diff.outputs.has_changes == 'true'
 
       - name: Verify dependency update
         if: steps.existing_pr.outputs.found != 'true' && steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/cargo-audit-autofix.yml
+++ b/.github/workflows/cargo-audit-autofix.yml
@@ -194,8 +194,32 @@ jobs:
           fi
           test -s target/audit-input/audit.sarif
 
-      - name: Write Codex prompt
+      - name: Check cargo audit findings
         if: steps.existing_pr.outputs.found != 'true'
+        id: audit_findings
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          result_count="$(ruby -rjson -e '
+            sarif = JSON.parse(File.read("target/audit-input/audit.sarif"))
+            puts sarif.fetch("runs", []).sum { |run| run.fetch("results", []).length }
+          ')"
+
+          if [[ "${result_count}" -gt 0 ]]; then
+            echo "has_findings=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_findings=false" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## Cargo audit autofix"
+              echo ""
+              echo "- action: \`skipped\`"
+              echo "- reason: downloaded SARIF contains no results"
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Write Codex prompt
+        if: steps.existing_pr.outputs.found != 'true' && steps.audit_findings.outputs.has_findings == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -224,7 +248,7 @@ jobs:
           PROMPT
 
       - name: Codex cargo audit autofix
-        if: steps.existing_pr.outputs.found != 'true'
+        if: steps.existing_pr.outputs.found != 'true' && steps.audit_findings.outputs.has_findings == 'true'
         uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -235,7 +259,7 @@ jobs:
           codex-args: --full-auto
 
       - name: Check for dependency changes
-        if: steps.existing_pr.outputs.found != 'true'
+        if: steps.existing_pr.outputs.found != 'true' && steps.audit_findings.outputs.has_findings == 'true'
         id: diff
         shell: bash
         run: |
@@ -250,6 +274,34 @@ jobs:
               echo "- action: \`no-changes\`"
               echo "- reason: Codex did not produce dependency updates."
             } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Validate dependency-only changes
+        if: steps.existing_pr.outputs.found != 'true' && steps.diff.outputs.has_changes == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          invalid_paths="$(git status --porcelain \
+            | sed -E 's/^...//; s/^.* -> //' \
+            | grep -Ev '^(Cargo\.toml|Cargo\.lock)$' || true)"
+
+          if [[ -n "${invalid_paths}" ]]; then
+            {
+              echo "Codex produced changes outside the dependency manifest allowlist:" >&2
+              echo "${invalid_paths}" >&2
+            }
+            {
+              echo "## Cargo audit autofix"
+              echo ""
+              echo "- action: \`failed\`"
+              echo "- reason: changes outside \`Cargo.toml\` / \`Cargo.lock\`"
+              echo ""
+              echo '```'
+              echo "${invalid_paths}"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
           fi
 
       - name: Verify dependency update
@@ -296,7 +348,7 @@ jobs:
 
           branch_name="codex/cargo-audit-autofix-${GITHUB_RUN_ID}"
           git switch -c "${branch_name}"
-          git add -A
+          git add Cargo.toml Cargo.lock
           git commit -m "fix(deps): resolve cargo audit findings"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --set-upstream origin "${branch_name}"
@@ -320,19 +372,26 @@ jobs:
           gh label create "${AUTOFIX_LABEL}" \
             --description "Automated cargo audit dependency fix" \
             --color "B60205" || true
-          gh pr edit "${pr_number}" --add-label "${AUTOFIX_LABEL}" --add-reviewer "${REVIEWER}"
+          gh pr edit "${pr_number}" --add-label "${AUTOFIX_LABEL}"
+          if gh pr edit "${pr_number}" --add-reviewer "${REVIEWER}"; then
+            reviewer_status="requested"
+          else
+            reviewer_status="request-failed"
+            echo "Reviewer request for ${REVIEWER} failed; leaving the autofix PR open." >&2
+          fi
 
           {
             echo "pr_number=${pr_number}"
             echo "pr_url=${pr_url}"
             echo "branch_name=${branch_name}"
+            echo "reviewer_status=${reviewer_status}"
           } >> "${GITHUB_OUTPUT}"
 
           {
             echo "## Cargo audit autofix PR"
             echo ""
             echo "- pr: ${pr_url}"
-            echo "- reviewer: \`${REVIEWER}\`"
+            echo "- reviewer: \`${REVIEWER}\` (${reviewer_status})"
             echo "- label: \`${AUTOFIX_LABEL}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: SARIF report
+          name: cargo-audit-sarif
           path: target/audit.sarif
           if-no-files-found: warn
       - name: Upload SARIF to GitHub code scanning


### PR DESCRIPTION
## Summary
- Add a Codex skill for fixing `cargo audit` SARIF findings with minimal dependency updates.
- Add a `workflow_run`-triggered Cargo Audit Autofix workflow for failed CI runs on `main` and internal PR branches.
- Rename the CI cargo audit artifact to `cargo-audit-sarif` so the autofix workflow can consume it reliably.

## Validation
- Parsed `.github/workflows/cargo-audit-autofix.yml`, `.github/workflows/ci.yml`, and the skill metadata with Ruby YAML.
- Ran `git diff --check` and `git diff --cached --check`.

## Notes
- `gh auth status` reports the local `gh` token is invalid, so the PR was created via the GitHub connector after pushing the branch with Git.