### PR TITLE
fix(deps): resolve cargo audit findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

- update `crossbeam-epoch` from 0.9.18 to 0.9.20
- update `quinn-proto` from 0.11.14 to 0.11.15
- update `anyhow` from 1.0.102 to 1.0.103

## Why

PR #285 exposed a cargo-audit failure that already exists on `main`; that PR does not change `Cargo.toml` or `Cargo.lock`.

This resolves:

- RUSTSEC-2026-0204 in `crossbeam-epoch`
- RUSTSEC-2026-0185 in `quinn-proto`
- RUSTSEC-2026-0190 warning in `anyhow`

The remaining `proc-macro-error2` unmaintained warning has no patched release and does not make cargo-audit fail.

## Scope

Only `Cargo.lock` changes. The patched versions retain the same normal dependency and feature definitions as the locked versions.

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `CARGO_NET_OFFLINE=true cargo audit --no-fetch --format sarif`
  - exits successfully
  - no vulnerability results
  - only the existing unmaintained `proc-macro-error2` warning remains
- verified all three crate archive SHA-256 values against the official crates.io sparse-index checksums

Local `cargo build` and `cargo test` could not start because this environment stalls while updating the crates.io index. GitHub Actions is expected to perform the full build and test verification.
